### PR TITLE
Add cherry blossom accent theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # dotenv files
 .env
 
+# Superpowers brainstorming mockups
+.superpowers/
+
 # User-specific files
 *.rsuser
 *.suo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Color definitions live in:
 - `SudokuBoardDrawable.cs` — board-specific colors as `static readonly Color` fields
 - `BoolToModeConverters.cs` — mode toggle button colors
 - XAML views — inline `AppThemeBinding` values for text and UI elements
+- `Resources/Images/sakura_branch_{light,dark}.svg` — watercolor cherry-blossom overlays (see Gotchas for the parity constraint)
 
 ## Code Style
 
@@ -67,3 +68,4 @@ Enforced via `.editorconfig`. Key conventions:
 - **Technique solver never guesses.** If the technique set is exhausted and the board is not full, `TechniqueSolver.Solve` returns `Solved = false`. Do not add a brute-force fallback — it would invalidate the "solvable by pure logic" guarantee that `SudokuGenerator` relies on for grading.
 - **Persistent candidates in `SolverState.CellCandidates`.** Techniques read candidates via `state.CellCandidates[r, c]` (not `UnitCandidates`, which is mask-only and ignores prior eliminations). Techniques mutate via `state.EliminateCandidate(r, c, digit)` or `state.PlacePropagating(r, c, digit)`. `Place` (used by `BitmaskSolver` backtracking) does NOT propagate peer updates — use it only when you don't need persistent candidate state across calls.
 - **Generator clue ranges.** Updated from the pre-redesign ranges; see `SudokuGenerator.GetClueRange`. Clue count is a secondary filter only — tier grade is the primary acceptance criterion, and ranges may overlap slightly at tier boundaries.
+- **Sakura SVG parity.** `sakura_branch_light.svg` and `sakura_branch_dark.svg` must share identical geometry — only color/opacity attributes may differ. `SakuraBranchParityTests` enforces this: edit one file, edit the other in the same commit.

--- a/Readme.md
+++ b/Readme.md
@@ -77,8 +77,8 @@ A Sudoku puzzle game built with C# and .NET MAUI, targeting Android and Windows.
   </tr>
   <tr>
     <td>Related Cells</td>
-    <td><img src="https://via.placeholder.com/24/ebe4db/ebe4db" alt="#ebe4db" /></td>
-    <td><code>#ebe4db</code></td>
+    <td><img src="https://via.placeholder.com/24/f0ddda/f0ddda" alt="#f0ddda" /></td>
+    <td><code>#f0ddda</code></td>
   </tr>
   <tr>
     <td>Same Number</td>
@@ -157,8 +157,8 @@ A Sudoku puzzle game built with C# and .NET MAUI, targeting Android and Windows.
   </tr>
   <tr>
     <td>Related Cells</td>
-    <td><img src="https://via.placeholder.com/24/2a2520/2a2520" alt="#2a2520" /></td>
-    <td><code>#2a2520</code></td>
+    <td><img src="https://via.placeholder.com/24/2c2422/2c2422" alt="#2c2422" /></td>
+    <td><code>#2c2422</code></td>
   </tr>
   <tr>
     <td>Same Number</td>

--- a/Readme.md
+++ b/Readme.md
@@ -32,72 +32,72 @@ A Sudoku puzzle game built with C# and .NET MAUI, targeting Android and Windows.
   </tr>
   <tr>
     <td>Page Background</td>
-    <td><img src="https://via.placeholder.com/24/f5f0eb/f5f0eb" alt="#f5f0eb" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#f5f0eb"><rect width="24" height="24" fill="#f5f0eb"/></svg></td>
     <td><code>#f5f0eb</code></td>
   </tr>
   <tr>
     <td>Primary Text</td>
-    <td><img src="https://via.placeholder.com/24/3d3632/3d3632" alt="#3d3632" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#3d3632"><rect width="24" height="24" fill="#3d3632"/></svg></td>
     <td><code>#3d3632</code></td>
   </tr>
   <tr>
     <td>Secondary Text</td>
-    <td><img src="https://via.placeholder.com/24/8a7e74/8a7e74" alt="#8a7e74" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#8a7e74"><rect width="24" height="24" fill="#8a7e74"/></svg></td>
     <td><code>#8a7e74</code></td>
   </tr>
   <tr>
     <td>Accent (Sage Green)</td>
-    <td><img src="https://via.placeholder.com/24/7d8c6e/7d8c6e" alt="#7d8c6e" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#7d8c6e"><rect width="24" height="24" fill="#7d8c6e"/></svg></td>
     <td><code>#7d8c6e</code></td>
   </tr>
   <tr>
     <td>Surface / Controls</td>
-    <td><img src="https://via.placeholder.com/24/e0d6cc/e0d6cc" alt="#e0d6cc" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#e0d6cc"><rect width="24" height="24" fill="#e0d6cc"/></svg></td>
     <td><code>#e0d6cc</code></td>
   </tr>
   <tr>
     <td>Dividers</td>
-    <td><img src="https://via.placeholder.com/24/c4b5a4/c4b5a4" alt="#c4b5a4" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#c4b5a4"><rect width="24" height="24" fill="#c4b5a4"/></svg></td>
     <td><code>#c4b5a4</code></td>
   </tr>
   <tr>
     <td>Board Thin Lines</td>
-    <td><img src="https://via.placeholder.com/24/c4b5a4/c4b5a4" alt="#c4b5a4" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#c4b5a4"><rect width="24" height="24" fill="#c4b5a4"/></svg></td>
     <td><code>#c4b5a4</code></td>
   </tr>
   <tr>
     <td>Board Thick Lines</td>
-    <td><img src="https://via.placeholder.com/24/5a4e44/5a4e44" alt="#5a4e44" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#5a4e44"><rect width="24" height="24" fill="#5a4e44"/></svg></td>
     <td><code>#5a4e44</code></td>
   </tr>
   <tr>
     <td>Selected Cell</td>
-    <td><img src="https://via.placeholder.com/24/ddd2c4/ddd2c4" alt="#ddd2c4" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#ddd2c4"><rect width="24" height="24" fill="#ddd2c4"/></svg></td>
     <td><code>#ddd2c4</code></td>
   </tr>
   <tr>
     <td>Related Cells</td>
-    <td><img src="https://via.placeholder.com/24/f0ddda/f0ddda" alt="#f0ddda" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#f0ddda"><rect width="24" height="24" fill="#f0ddda"/></svg></td>
     <td><code>#f0ddda</code></td>
   </tr>
   <tr>
     <td>Same Number</td>
-    <td><img src="https://via.placeholder.com/24/d8e0d0/d8e0d0" alt="#d8e0d0" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#d8e0d0"><rect width="24" height="24" fill="#d8e0d0"/></svg></td>
     <td><code>#d8e0d0</code></td>
   </tr>
   <tr>
     <td>Error Cell</td>
-    <td><img src="https://via.placeholder.com/24/e8c4c0/e8c4c0" alt="#e8c4c0" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#e8c4c0"><rect width="24" height="24" fill="#e8c4c0"/></svg></td>
     <td><code>#e8c4c0</code></td>
   </tr>
   <tr>
     <td>Player Text</td>
-    <td><img src="https://via.placeholder.com/24/7d8c6e/7d8c6e" alt="#7d8c6e" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#7d8c6e"><rect width="24" height="24" fill="#7d8c6e"/></svg></td>
     <td><code>#7d8c6e</code></td>
   </tr>
   <tr>
     <td>Candidate Text</td>
-    <td><img src="https://via.placeholder.com/24/8a7e74/8a7e74" alt="#8a7e74" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#8a7e74"><rect width="24" height="24" fill="#8a7e74"/></svg></td>
     <td><code>#8a7e74</code></td>
   </tr>
 </table>
@@ -112,72 +112,72 @@ A Sudoku puzzle game built with C# and .NET MAUI, targeting Android and Windows.
   </tr>
   <tr>
     <td>Page Background</td>
-    <td><img src="https://via.placeholder.com/24/1e1b18/1e1b18" alt="#1e1b18" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#1e1b18"><rect width="24" height="24" fill="#1e1b18"/></svg></td>
     <td><code>#1e1b18</code></td>
   </tr>
   <tr>
     <td>Primary Text</td>
-    <td><img src="https://via.placeholder.com/24/e0d8cf/e0d8cf" alt="#e0d8cf" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#e0d8cf"><rect width="24" height="24" fill="#e0d8cf"/></svg></td>
     <td><code>#e0d8cf</code></td>
   </tr>
   <tr>
     <td>Secondary Text</td>
-    <td><img src="https://via.placeholder.com/24/7a7068/7a7068" alt="#7a7068" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#7a7068"><rect width="24" height="24" fill="#7a7068"/></svg></td>
     <td><code>#7a7068</code></td>
   </tr>
   <tr>
     <td>Accent (Sage Green)</td>
-    <td><img src="https://via.placeholder.com/24/9aab88/9aab88" alt="#9aab88" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#9aab88"><rect width="24" height="24" fill="#9aab88"/></svg></td>
     <td><code>#9aab88</code></td>
   </tr>
   <tr>
     <td>Surface / Controls</td>
-    <td><img src="https://via.placeholder.com/24/2d2925/2d2925" alt="#2d2925" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#2d2925"><rect width="24" height="24" fill="#2d2925"/></svg></td>
     <td><code>#2d2925</code></td>
   </tr>
   <tr>
     <td>Dividers</td>
-    <td><img src="https://via.placeholder.com/24/4a4038/4a4038" alt="#4a4038" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#4a4038"><rect width="24" height="24" fill="#4a4038"/></svg></td>
     <td><code>#4a4038</code></td>
   </tr>
   <tr>
     <td>Board Thin Lines</td>
-    <td><img src="https://via.placeholder.com/24/4a4038/4a4038" alt="#4a4038" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#4a4038"><rect width="24" height="24" fill="#4a4038"/></svg></td>
     <td><code>#4a4038</code></td>
   </tr>
   <tr>
     <td>Board Thick Lines</td>
-    <td><img src="https://via.placeholder.com/24/7a7068/7a7068" alt="#7a7068" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#7a7068"><rect width="24" height="24" fill="#7a7068"/></svg></td>
     <td><code>#7a7068</code></td>
   </tr>
   <tr>
     <td>Selected Cell</td>
-    <td><img src="https://via.placeholder.com/24/3a3228/3a3228" alt="#3a3228" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#3a3228"><rect width="24" height="24" fill="#3a3228"/></svg></td>
     <td><code>#3a3228</code></td>
   </tr>
   <tr>
     <td>Related Cells</td>
-    <td><img src="https://via.placeholder.com/24/2c2422/2c2422" alt="#2c2422" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#2c2422"><rect width="24" height="24" fill="#2c2422"/></svg></td>
     <td><code>#2c2422</code></td>
   </tr>
   <tr>
     <td>Same Number</td>
-    <td><img src="https://via.placeholder.com/24/2d3328/2d3328" alt="#2d3328" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#2d3328"><rect width="24" height="24" fill="#2d3328"/></svg></td>
     <td><code>#2d3328</code></td>
   </tr>
   <tr>
     <td>Error Cell</td>
-    <td><img src="https://via.placeholder.com/24/8b4040/8b4040" alt="#8b4040" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#8b4040"><rect width="24" height="24" fill="#8b4040"/></svg></td>
     <td><code>#8b4040</code></td>
   </tr>
   <tr>
     <td>Player Text</td>
-    <td><img src="https://via.placeholder.com/24/9aab88/9aab88" alt="#9aab88" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#9aab88"><rect width="24" height="24" fill="#9aab88"/></svg></td>
     <td><code>#9aab88</code></td>
   </tr>
   <tr>
     <td>Candidate Text</td>
-    <td><img src="https://via.placeholder.com/24/7a7068/7a7068" alt="#7a7068" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#7a7068"><rect width="24" height="24" fill="#7a7068"/></svg></td>
     <td><code>#7a7068</code></td>
   </tr>
 </table>
@@ -192,27 +192,27 @@ A Sudoku puzzle game built with C# and .NET MAUI, targeting Android and Windows.
   </tr>
   <tr>
     <td>Gentle</td>
-    <td><img src="https://via.placeholder.com/24/8a9a7b/8a9a7b" alt="#8a9a7b" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#8a9a7b"><rect width="24" height="24" fill="#8a9a7b"/></svg></td>
     <td><code>#8a9a7b</code></td>
   </tr>
   <tr>
     <td>Steady</td>
-    <td><img src="https://via.placeholder.com/24/b5a67d/b5a67d" alt="#b5a67d" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#b5a67d"><rect width="24" height="24" fill="#b5a67d"/></svg></td>
     <td><code>#b5a67d</code></td>
   </tr>
   <tr>
     <td>Challenging</td>
-    <td><img src="https://via.placeholder.com/24/c49a6c/c49a6c" alt="#c49a6c" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#c49a6c"><rect width="24" height="24" fill="#c49a6c"/></svg></td>
     <td><code>#c49a6c</code></td>
   </tr>
   <tr>
     <td>Deep</td>
-    <td><img src="https://via.placeholder.com/24/a67563/a67563" alt="#a67563" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#a67563"><rect width="24" height="24" fill="#a67563"/></svg></td>
     <td><code>#a67563</code></td>
   </tr>
   <tr>
     <td>Profound</td>
-    <td><img src="https://via.placeholder.com/24/8b6d7b/8b6d7b" alt="#8b6d7b" /></td>
+    <td><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" role="img" aria-label="#8b6d7b"><rect width="24" height="24" fill="#8b6d7b"/></svg></td>
     <td><code>#8b6d7b</code></td>
   </tr>
 </table>

--- a/Sudoku.App/Controls/SudokuBoardDrawable.cs
+++ b/Sudoku.App/Controls/SudokuBoardDrawable.cs
@@ -13,7 +13,7 @@ public class SudokuBoardDrawable : IDrawable
     // Dark theme colors — warm earth tones
     private static readonly Color s_darkBackground = Color.FromArgb("#1e1b18");
     private static readonly Color s_darkSelectedCell = Color.FromArgb("#3a3228");
-    private static readonly Color s_darkRelatedCell = Color.FromArgb("#2a2520");
+    private static readonly Color s_darkRelatedCell = Color.FromArgb("#2e2224");
     private static readonly Color s_darkSameNumber = Color.FromArgb("#2d3328");
     private static readonly Color s_darkErrorCell = Color.FromArgb("#8b4040");
     private static readonly Color s_darkThinLine = Color.FromArgb("#4a4038");
@@ -25,7 +25,7 @@ public class SudokuBoardDrawable : IDrawable
     // Light theme colors — warm earth tones
     private static readonly Color s_lightBackground = Color.FromArgb("#f5f0eb");
     private static readonly Color s_lightSelectedCell = Color.FromArgb("#ddd2c4");
-    private static readonly Color s_lightRelatedCell = Color.FromArgb("#ebe4db");
+    private static readonly Color s_lightRelatedCell = Color.FromArgb("#f0ddda");
     private static readonly Color s_lightSameNumber = Color.FromArgb("#d8e0d0");
     private static readonly Color s_lightErrorCell = Color.FromArgb("#e8c4c0");
     private static readonly Color s_lightThinLine = Color.FromArgb("#c4b5a4");

--- a/Sudoku.App/Controls/SudokuBoardDrawable.cs
+++ b/Sudoku.App/Controls/SudokuBoardDrawable.cs
@@ -13,7 +13,7 @@ public class SudokuBoardDrawable : IDrawable
     // Dark theme colors — warm earth tones
     private static readonly Color s_darkBackground = Color.FromArgb("#1e1b18");
     private static readonly Color s_darkSelectedCell = Color.FromArgb("#3a3228");
-    private static readonly Color s_darkRelatedCell = Color.FromArgb("#2e2224");
+    private static readonly Color s_darkRelatedCell = Color.FromArgb("#2c2422");
     private static readonly Color s_darkSameNumber = Color.FromArgb("#2d3328");
     private static readonly Color s_darkErrorCell = Color.FromArgb("#8b4040");
     private static readonly Color s_darkThinLine = Color.FromArgb("#4a4038");

--- a/Sudoku.App/Resources/Images/sakura_branch_dark.svg
+++ b/Sudoku.App/Resources/Images/sakura_branch_dark.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" opacity="0.4">
+  <defs>
+    <filter id="blur-branch" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="2" />
+    </filter>
+    <filter id="blur-bloom" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" />
+    </filter>
+  </defs>
+  <path d="M 610 60 Q 520 140 480 220 Q 430 310 380 370 Q 340 410 280 440" fill="none" stroke="#6a4f40" stroke-width="5" filter="url(#blur-branch)" />
+  <path d="M 510 165 Q 545 225 530 305" fill="none" stroke="#6a4f40" stroke-width="3.5" filter="url(#blur-branch)" />
+  <g filter="url(#blur-bloom)">
+    <circle cx="595" cy="65" r="22" fill="#a87682" />
+    <circle cx="610" cy="85" r="18" fill="#966374" />
+    <circle cx="580" cy="100" r="15" fill="#a87682" />
+    <circle cx="555" cy="140" r="19" fill="#966374" />
+    <circle cx="540" cy="158" r="14" fill="#a87682" />
+    <circle cx="510" cy="185" r="18" fill="#a87682" />
+    <circle cx="495" cy="200" r="13" fill="#966374" />
+    <circle cx="475" cy="240" r="19" fill="#a87682" />
+    <circle cx="490" cy="258" r="14" fill="#966374" />
+    <circle cx="460" cy="265" r="12" fill="#a87682" />
+    <circle cx="430" cy="305" r="17" fill="#966374" />
+    <circle cx="445" cy="322" r="13" fill="#a87682" />
+    <circle cx="395" cy="360" r="18" fill="#a87682" />
+    <circle cx="410" cy="378" r="14" fill="#966374" />
+    <circle cx="520" cy="260" r="16" fill="#a87682" />
+    <circle cx="532" cy="278" r="12" fill="#966374" />
+    <circle cx="345" cy="405" r="16" fill="#a87682" />
+    <circle cx="360" cy="420" r="12" fill="#966374" />
+    <circle cx="300" cy="440" r="14" fill="#966374" />
+    <circle cx="285" cy="452" r="11" fill="#a87682" />
+    <circle cx="560" cy="210" r="12" fill="#a87682" />
+    <circle cx="550" cy="222" r="9" fill="#966374" />
+  </g>
+  <ellipse cx="505" cy="225" rx="14" ry="6" transform="rotate(25 505 225)" fill="#6d7a5e" filter="url(#blur-branch)" />
+  <ellipse cx="420" cy="342" rx="13" ry="6" transform="rotate(40 420 342)" fill="#6d7a5e" filter="url(#blur-branch)" />
+</svg>

--- a/Sudoku.App/Resources/Images/sakura_branch_light.svg
+++ b/Sudoku.App/Resources/Images/sakura_branch_light.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" opacity="0.55">
+  <defs>
+    <filter id="blur-branch" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="2" />
+    </filter>
+    <filter id="blur-bloom" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" />
+    </filter>
+  </defs>
+  <path d="M 610 60 Q 520 140 480 220 Q 430 310 380 370 Q 340 410 280 440" fill="none" stroke="#a08778" stroke-width="5" filter="url(#blur-branch)" />
+  <path d="M 510 165 Q 545 225 530 305" fill="none" stroke="#a08778" stroke-width="3.5" filter="url(#blur-branch)" />
+  <g filter="url(#blur-bloom)">
+    <circle cx="595" cy="65" r="22" fill="#f2cdd1" />
+    <circle cx="610" cy="85" r="18" fill="#edb9c2" />
+    <circle cx="580" cy="100" r="15" fill="#f2cdd1" />
+    <circle cx="555" cy="140" r="19" fill="#edb9c2" />
+    <circle cx="540" cy="158" r="14" fill="#f2cdd1" />
+    <circle cx="510" cy="185" r="18" fill="#f2cdd1" />
+    <circle cx="495" cy="200" r="13" fill="#edb9c2" />
+    <circle cx="475" cy="240" r="19" fill="#f2cdd1" />
+    <circle cx="490" cy="258" r="14" fill="#edb9c2" />
+    <circle cx="460" cy="265" r="12" fill="#f2cdd1" />
+    <circle cx="430" cy="305" r="17" fill="#edb9c2" />
+    <circle cx="445" cy="322" r="13" fill="#f2cdd1" />
+    <circle cx="395" cy="360" r="18" fill="#f2cdd1" />
+    <circle cx="410" cy="378" r="14" fill="#edb9c2" />
+    <circle cx="520" cy="260" r="16" fill="#f2cdd1" />
+    <circle cx="532" cy="278" r="12" fill="#edb9c2" />
+    <circle cx="345" cy="405" r="16" fill="#f2cdd1" />
+    <circle cx="360" cy="420" r="12" fill="#edb9c2" />
+    <circle cx="300" cy="440" r="14" fill="#edb9c2" />
+    <circle cx="285" cy="452" r="11" fill="#f2cdd1" />
+    <circle cx="560" cy="210" r="12" fill="#f2cdd1" />
+    <circle cx="550" cy="222" r="9" fill="#edb9c2" />
+  </g>
+  <ellipse cx="505" cy="225" rx="14" ry="6" transform="rotate(25 505 225)" fill="#a8b89a" filter="url(#blur-branch)" />
+  <ellipse cx="420" cy="342" rx="13" ry="6" transform="rotate(40 420 342)" fill="#a8b89a" filter="url(#blur-branch)" />
+</svg>

--- a/Sudoku.App/Resources/Splash/splash.svg
+++ b/Sudoku.App/Resources/Splash/splash.svg
@@ -1,8 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter id="splashBlur" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="3" />
+        </filter>
+    </defs>
+
+    <!-- Sakura branch — light palette, painted BEFORE the Ensō so it sits behind -->
+    <path d="M 465 30 Q 410 70 380 120 Q 350 180 310 220"
+          fill="none" stroke="#a08778" stroke-width="3" opacity="0.5" filter="url(#splashBlur)" />
+    <g opacity="0.6" filter="url(#splashBlur)">
+        <circle cx="455" cy="35" r="14" fill="#f2cdd1" />
+        <circle cx="465" cy="50" r="12" fill="#edb9c2" />
+        <circle cx="445" cy="60" r="10" fill="#f2cdd1" />
+        <circle cx="410" cy="90" r="12" fill="#edb9c2" />
+        <circle cx="420" cy="105" r="10" fill="#f2cdd1" />
+        <circle cx="380" cy="135" r="11" fill="#f2cdd1" />
+        <circle cx="395" cy="150" r="9" fill="#edb9c2" />
+        <circle cx="350" cy="180" r="11" fill="#f2cdd1" />
+        <circle cx="335" cy="195" r="9" fill="#edb9c2" />
+        <circle cx="310" cy="215" r="10" fill="#f2cdd1" />
+    </g>
+    <ellipse cx="395" cy="125" rx="9" ry="4" transform="rotate(30 395 125)" fill="#a8b89a" opacity="0.55" filter="url(#splashBlur)" />
+
     <!-- Ensō — zen brush-stroke circle, larger for splash -->
     <!-- Center: (228, 228), radius: 120, gap at top-right -->
-
     <!-- Main body — bold confident stroke -->
     <path d="M 320 151 A 120 120 0 1 1 187 115"
           fill="none" stroke="white" stroke-width="28" stroke-linecap="round"/>

--- a/Sudoku.App/Views/GamePage.xaml
+++ b/Sudoku.App/Views/GamePage.xaml
@@ -9,6 +9,16 @@
 
     <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto" Padding="8">
 
+        <!-- Sakura branch overlay — masked by the opaque board in Row 2 -->
+        <Image Source="{AppThemeBinding Light=sakura_branch_light.png, Dark=sakura_branch_dark.png}"
+               Grid.RowSpan="6"
+               InputTransparent="True"
+               Aspect="AspectFit"
+               HorizontalOptions="End"
+               VerticalOptions="Start"
+               WidthRequest="320"
+               HeightRequest="480" />
+
         <!-- Row 0: Navigation bar -->
         <Grid ColumnDefinitions="Auto,*,Auto" Padding="8,4">
             <Button Text="&#9664; Back" BackgroundColor="Transparent"

--- a/Sudoku.App/Views/MenuPage.xaml
+++ b/Sudoku.App/Views/MenuPage.xaml
@@ -11,7 +11,7 @@
         <VerticalStackLayout VerticalOptions="Center" Spacing="8">
             <Label Text="SUDOKU ZEN" FontSize="32" HorizontalTextAlignment="Center" CharacterSpacing="3"
                    TextColor="{AppThemeBinding Light=#3d3632, Dark=#e0d8cf}" />
-            <Label Text="SOLVE FOR ONE" FontSize="11" CharacterSpacing="6" HorizontalTextAlignment="Center"
+            <Label Text="A MINDFUL MOMENT" FontSize="11" CharacterSpacing="6" HorizontalTextAlignment="Center"
                    TextColor="{AppThemeBinding Light=#8a7e74, Dark=#7a7068}" />
 
             <!-- Decorative separator -->

--- a/Sudoku.App/Views/MenuPage.xaml
+++ b/Sudoku.App/Views/MenuPage.xaml
@@ -8,6 +8,15 @@
              BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}">
 
     <Grid RowDefinitions="*,Auto" Padding="24">
+        <Image Source="{AppThemeBinding Light=sakura_branch_light.png, Dark=sakura_branch_dark.png}"
+               Grid.RowSpan="2"
+               InputTransparent="True"
+               Aspect="AspectFit"
+               HorizontalOptions="End"
+               VerticalOptions="Start"
+               WidthRequest="320"
+               HeightRequest="480" />
+
         <VerticalStackLayout VerticalOptions="Center" Spacing="8">
             <Label Text="SUDOKU ZEN" FontSize="32" HorizontalTextAlignment="Center" CharacterSpacing="3"
                    TextColor="{AppThemeBinding Light=#3d3632, Dark=#e0d8cf}" />

--- a/Sudoku.App/Views/SettingsPage.xaml
+++ b/Sudoku.App/Views/SettingsPage.xaml
@@ -8,6 +8,15 @@
              BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}">
 
     <Grid RowDefinitions="Auto,*" Padding="24,16">
+        <Image Source="{AppThemeBinding Light=sakura_branch_light.png, Dark=sakura_branch_dark.png}"
+               Grid.RowSpan="2"
+               InputTransparent="True"
+               Aspect="AspectFit"
+               HorizontalOptions="End"
+               VerticalOptions="Start"
+               WidthRequest="320"
+               HeightRequest="480" />
+
         <HorizontalStackLayout Spacing="12">
             <Button Text="&#9664;" BackgroundColor="Transparent"
                     TextColor="{AppThemeBinding Light=#8a7e74, Dark=#7a7068}"

--- a/Sudoku.Tests/SakuraBranchParityTests.cs
+++ b/Sudoku.Tests/SakuraBranchParityTests.cs
@@ -1,0 +1,69 @@
+using System.Xml.Linq;
+
+namespace Sudoku.Tests;
+
+public class SakuraBranchParityTests
+{
+    private static readonly HashSet<string> s_colorAttributes = new(StringComparer.Ordinal)
+    {
+        "fill",
+        "stroke",
+        "opacity",
+        "stop-color",
+        "stop-opacity",
+        "stdDeviation"
+    };
+
+    [Test]
+    public void LightAndDarkSvgsShouldHaveIdenticalGeometry()
+    {
+        var baseDir = TestContext.CurrentContext.TestDirectory;
+        var lightPath = Path.Combine(baseDir, "sakura_branch_light.svg");
+        var darkPath = Path.Combine(baseDir, "sakura_branch_dark.svg");
+
+        File.Exists(lightPath).Should().BeTrue($"missing SVG: {lightPath}");
+        File.Exists(darkPath).Should().BeTrue($"missing SVG: {darkPath}");
+
+        var light = XDocument.Load(lightPath);
+        var dark = XDocument.Load(darkPath);
+
+        AssertElementParity(light.Root!, dark.Root!, "/" + light.Root!.Name.LocalName);
+    }
+
+    private static void AssertElementParity(XElement light, XElement dark, string path)
+    {
+        light.Name.LocalName.Should().Be(dark.Name.LocalName,
+            $"element name differs at {path}");
+
+        var lightAttrs = light.Attributes()
+            .Where(a => !s_colorAttributes.Contains(a.Name.LocalName))
+            .OrderBy(a => a.Name.LocalName, StringComparer.Ordinal)
+            .ToList();
+        var darkAttrs = dark.Attributes()
+            .Where(a => !s_colorAttributes.Contains(a.Name.LocalName))
+            .OrderBy(a => a.Name.LocalName, StringComparer.Ordinal)
+            .ToList();
+
+        lightAttrs.Select(a => a.Name.LocalName).Should().Equal(
+            darkAttrs.Select(a => a.Name.LocalName),
+            $"geometry attribute set differs at {path}");
+
+        for (var i = 0; i < lightAttrs.Count; i++)
+        {
+            lightAttrs[i].Value.Should().Be(darkAttrs[i].Value,
+                $"attribute {lightAttrs[i].Name.LocalName} differs at {path}");
+        }
+
+        var lightChildren = light.Elements().ToList();
+        var darkChildren = dark.Elements().ToList();
+
+        lightChildren.Count.Should().Be(darkChildren.Count,
+            $"child count differs at {path}");
+
+        for (var i = 0; i < lightChildren.Count; i++)
+        {
+            var childPath = $"{path}/{lightChildren[i].Name.LocalName}[{i}]";
+            AssertElementParity(lightChildren[i], darkChildren[i], childPath);
+        }
+    }
+}

--- a/Sudoku.Tests/Sudoku.Tests.csproj
+++ b/Sudoku.Tests/Sudoku.Tests.csproj
@@ -41,4 +41,17 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\Sudoku.App\Resources\Images\sakura_branch_light.svg"
+          Link="sakura_branch_light.svg"
+          Condition="Exists('..\Sudoku.App\Resources\Images\sakura_branch_light.svg')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\Sudoku.App\Resources\Images\sakura_branch_dark.svg"
+          Link="sakura_branch_dark.svg"
+          Condition="Exists('..\Sudoku.App\Resources\Images\sakura_branch_dark.svg')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/docs/superpowers/plans/2026-04-21-cherry-blossom-theme.md
+++ b/docs/superpowers/plans/2026-04-21-cherry-blossom-theme.md
@@ -1,0 +1,695 @@
+# Cherry Blossom Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a subtle sakura watercolor branch to the top-right corner of every screen plus splash, and shift the board's row/column/box highlight from warm cream to a near-imperceptible pink.
+
+**Architecture:** Two static SVG files (light/dark variants with identical geometry) are dropped into `Sudoku.App/Resources/Images/`, picked up by MAUI's resizetizer glob, and referenced from each page via `AppThemeBinding` on an `<Image>` element. A parity test in `Sudoku.Tests` loads both SVGs and asserts that every element/attribute other than color/opacity values matches.
+
+**Tech Stack:** MAUI (`net10.0-android` / `net10.0-windows10.0.19041.0`), XAML, C# 12, NUnit 4, FluentAssertions, `System.Xml.Linq`.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-cherry-blossom-theme-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+
+- `Sudoku.App/Resources/Images/sakura_branch_light.svg` — watercolor branch for light theme.
+- `Sudoku.App/Resources/Images/sakura_branch_dark.svg` — same geometry, dusty-rose palette + lower root opacity.
+- `Sudoku.Tests/SakuraBranchParityTests.cs` — enforces geometry parity between the two SVGs.
+
+**Modify:**
+
+- `Sudoku.App/Controls/SudokuBoardDrawable.cs` — two `static readonly Color` fields.
+- `Sudoku.App/Views/MenuPage.xaml` — one new `<Image>` element.
+- `Sudoku.App/Views/SettingsPage.xaml` — one new `<Image>` element.
+- `Sudoku.App/Views/GamePage.xaml` — one new `<Image>` element.
+- `Sudoku.App/Resources/Splash/splash.svg` — branch paths inserted behind the existing Ensō.
+- `Sudoku.Tests/Sudoku.Tests.csproj` — copy the two SVGs into test output.
+
+---
+
+## Task 1: Wire SVG files into the test project's output
+
+**Files:**
+- Modify: `Sudoku.Tests/Sudoku.Tests.csproj`
+
+- [ ] **Step 1: Add the two SVGs to the test project's `None` item group so they are copied next to the test assembly at build time**
+
+Open `Sudoku.Tests/Sudoku.Tests.csproj`. Find the existing `<ItemGroup>` that contains `sudokus.json` / `sudokus.txt`:
+
+```xml
+<ItemGroup>
+  <None Update="sudokus.json">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Update="sudokus.txt">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+</ItemGroup>
+```
+
+Add a new `<ItemGroup>` immediately below it:
+
+```xml
+<ItemGroup>
+  <None Include="..\Sudoku.App\Resources\Images\sakura_branch_light.svg" Link="sakura_branch_light.svg">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+  <None Include="..\Sudoku.App\Resources\Images\sakura_branch_dark.svg" Link="sakura_branch_dark.svg">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+</ItemGroup>
+```
+
+The `Link` attribute ensures the SVG lands at the root of the test output directory (not inside a nested `Resources/Images/` subtree).
+
+- [ ] **Step 2: Verify the project still builds even though the SVGs don't exist yet**
+
+Run:
+
+```bash
+dotnet build Sudoku.Tests
+```
+
+Expected: build succeeds. The `None Include=…` with a missing file emits a warning (`MSB3246` or similar), not an error — that's fine for now because Task 3 and Task 4 will create the files. If the build fails outright, re-check the csproj syntax.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sudoku.Tests/Sudoku.Tests.csproj
+git commit -m "test: wire sakura branch SVGs into test output"
+```
+
+---
+
+## Task 2: Write the SVG parity test (red)
+
+**Files:**
+- Create: `Sudoku.Tests/SakuraBranchParityTests.cs`
+
+- [ ] **Step 1: Create the test file**
+
+Create `Sudoku.Tests/SakuraBranchParityTests.cs` with this exact content:
+
+```csharp
+using System.Xml.Linq;
+
+namespace Sudoku.Tests;
+
+public class SakuraBranchParityTests
+{
+    private static readonly HashSet<string> s_colorAttributes = new(StringComparer.Ordinal)
+    {
+        "fill",
+        "stroke",
+        "opacity",
+        "stop-color",
+        "stop-opacity",
+        "stdDeviation"
+    };
+
+    [Test]
+    public void LightAndDarkSvgsShouldHaveIdenticalGeometry()
+    {
+        var baseDir = TestContext.CurrentContext.TestDirectory;
+        var lightPath = Path.Combine(baseDir, "sakura_branch_light.svg");
+        var darkPath = Path.Combine(baseDir, "sakura_branch_dark.svg");
+
+        File.Exists(lightPath).Should().BeTrue($"missing SVG: {lightPath}");
+        File.Exists(darkPath).Should().BeTrue($"missing SVG: {darkPath}");
+
+        var light = XDocument.Load(lightPath);
+        var dark = XDocument.Load(darkPath);
+
+        AssertElementParity(light.Root!, dark.Root!, "/" + light.Root!.Name.LocalName);
+    }
+
+    private static void AssertElementParity(XElement light, XElement dark, string path)
+    {
+        light.Name.LocalName.Should().Be(dark.Name.LocalName,
+            $"element name differs at {path}");
+
+        var lightAttrs = light.Attributes()
+            .Where(a => !s_colorAttributes.Contains(a.Name.LocalName))
+            .OrderBy(a => a.Name.LocalName, StringComparer.Ordinal)
+            .ToList();
+        var darkAttrs = dark.Attributes()
+            .Where(a => !s_colorAttributes.Contains(a.Name.LocalName))
+            .OrderBy(a => a.Name.LocalName, StringComparer.Ordinal)
+            .ToList();
+
+        lightAttrs.Select(a => a.Name.LocalName).Should().Equal(
+            darkAttrs.Select(a => a.Name.LocalName),
+            $"geometry attribute set differs at {path}");
+
+        for (var i = 0; i < lightAttrs.Count; i++)
+        {
+            lightAttrs[i].Value.Should().Be(darkAttrs[i].Value,
+                $"attribute {lightAttrs[i].Name.LocalName} differs at {path}");
+        }
+
+        var lightChildren = light.Elements().ToList();
+        var darkChildren = dark.Elements().ToList();
+
+        lightChildren.Count.Should().Be(darkChildren.Count,
+            $"child count differs at {path}");
+
+        for (var i = 0; i < lightChildren.Count; i++)
+        {
+            var childPath = $"{path}/{lightChildren[i].Name.LocalName}[{i}]";
+            AssertElementParity(lightChildren[i], darkChildren[i], childPath);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test — expect it to fail (files don't exist yet)**
+
+Run:
+
+```bash
+dotnet test Sudoku.Tests --filter "FullyQualifiedName~SakuraBranchParityTests"
+```
+
+Expected: **FAIL** with message like `missing SVG: .../sakura_branch_light.svg`. This confirms the test exercises the code path we care about.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sudoku.Tests/SakuraBranchParityTests.cs
+git commit -m "test: add SVG parity test for sakura branch assets"
+```
+
+---
+
+## Task 3: Author `sakura_branch_light.svg`
+
+**Files:**
+- Create: `Sudoku.App/Resources/Images/sakura_branch_light.svg`
+
+- [ ] **Step 1: Create the light-theme SVG**
+
+Create `Sudoku.App/Resources/Images/sakura_branch_light.svg` with this exact content:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" opacity="0.55">
+  <defs>
+    <filter id="blur-branch" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="2" />
+    </filter>
+    <filter id="blur-bloom" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" />
+    </filter>
+  </defs>
+  <path d="M 610 60 Q 520 140 480 220 Q 430 310 380 370 Q 340 410 280 440" fill="none" stroke="#a08778" stroke-width="5" filter="url(#blur-branch)" />
+  <path d="M 510 165 Q 545 225 530 305" fill="none" stroke="#a08778" stroke-width="3.5" filter="url(#blur-branch)" />
+  <g filter="url(#blur-bloom)">
+    <circle cx="595" cy="65" r="22" fill="#f2cdd1" />
+    <circle cx="610" cy="85" r="18" fill="#edb9c2" />
+    <circle cx="580" cy="100" r="15" fill="#f2cdd1" />
+    <circle cx="555" cy="140" r="19" fill="#edb9c2" />
+    <circle cx="540" cy="158" r="14" fill="#f2cdd1" />
+    <circle cx="510" cy="185" r="18" fill="#f2cdd1" />
+    <circle cx="495" cy="200" r="13" fill="#edb9c2" />
+    <circle cx="475" cy="240" r="19" fill="#f2cdd1" />
+    <circle cx="490" cy="258" r="14" fill="#edb9c2" />
+    <circle cx="460" cy="265" r="12" fill="#f2cdd1" />
+    <circle cx="430" cy="305" r="17" fill="#edb9c2" />
+    <circle cx="445" cy="322" r="13" fill="#f2cdd1" />
+    <circle cx="395" cy="360" r="18" fill="#f2cdd1" />
+    <circle cx="410" cy="378" r="14" fill="#edb9c2" />
+    <circle cx="520" cy="260" r="16" fill="#f2cdd1" />
+    <circle cx="532" cy="278" r="12" fill="#edb9c2" />
+    <circle cx="345" cy="405" r="16" fill="#f2cdd1" />
+    <circle cx="360" cy="420" r="12" fill="#edb9c2" />
+    <circle cx="300" cy="440" r="14" fill="#edb9c2" />
+    <circle cx="285" cy="452" r="11" fill="#f2cdd1" />
+    <circle cx="560" cy="210" r="12" fill="#f2cdd1" />
+    <circle cx="550" cy="222" r="9" fill="#edb9c2" />
+  </g>
+  <ellipse cx="505" cy="225" rx="14" ry="6" transform="rotate(25 505 225)" fill="#a8b89a" filter="url(#blur-branch)" />
+  <ellipse cx="420" cy="342" rx="13" ry="6" transform="rotate(40 420 342)" fill="#a8b89a" filter="url(#blur-branch)" />
+</svg>
+```
+
+- [ ] **Step 2: Run the parity test — still expect FAIL (dark SVG missing)**
+
+Run:
+
+```bash
+dotnet test Sudoku.Tests --filter "FullyQualifiedName~SakuraBranchParityTests"
+```
+
+Expected: **FAIL** with `missing SVG: .../sakura_branch_dark.svg`. This is the expected red state — proves the test picked up the light file but still demands the dark one.
+
+Do **not** commit yet — commit after Task 4 when the test passes.
+
+---
+
+## Task 4: Author `sakura_branch_dark.svg` with identical geometry
+
+**Files:**
+- Create: `Sudoku.App/Resources/Images/sakura_branch_dark.svg`
+
+- [ ] **Step 1: Create the dark-theme SVG**
+
+Create `Sudoku.App/Resources/Images/sakura_branch_dark.svg` with this exact content. Note: every `d`, `cx`, `cy`, `r`, `rx`, `ry`, `x`, `y`, `width`, `height`, `transform`, `stroke-width`, `filter`, and `id` attribute is identical to `sakura_branch_light.svg`. Only `opacity`, `fill`, `stroke`, and `stdDeviation` values differ:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 900" opacity="0.4">
+  <defs>
+    <filter id="blur-branch" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="2" />
+    </filter>
+    <filter id="blur-bloom" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" />
+    </filter>
+  </defs>
+  <path d="M 610 60 Q 520 140 480 220 Q 430 310 380 370 Q 340 410 280 440" fill="none" stroke="#6a4f40" stroke-width="5" filter="url(#blur-branch)" />
+  <path d="M 510 165 Q 545 225 530 305" fill="none" stroke="#6a4f40" stroke-width="3.5" filter="url(#blur-branch)" />
+  <g filter="url(#blur-bloom)">
+    <circle cx="595" cy="65" r="22" fill="#a87682" />
+    <circle cx="610" cy="85" r="18" fill="#966374" />
+    <circle cx="580" cy="100" r="15" fill="#a87682" />
+    <circle cx="555" cy="140" r="19" fill="#966374" />
+    <circle cx="540" cy="158" r="14" fill="#a87682" />
+    <circle cx="510" cy="185" r="18" fill="#a87682" />
+    <circle cx="495" cy="200" r="13" fill="#966374" />
+    <circle cx="475" cy="240" r="19" fill="#a87682" />
+    <circle cx="490" cy="258" r="14" fill="#966374" />
+    <circle cx="460" cy="265" r="12" fill="#a87682" />
+    <circle cx="430" cy="305" r="17" fill="#966374" />
+    <circle cx="445" cy="322" r="13" fill="#a87682" />
+    <circle cx="395" cy="360" r="18" fill="#a87682" />
+    <circle cx="410" cy="378" r="14" fill="#966374" />
+    <circle cx="520" cy="260" r="16" fill="#a87682" />
+    <circle cx="532" cy="278" r="12" fill="#966374" />
+    <circle cx="345" cy="405" r="16" fill="#a87682" />
+    <circle cx="360" cy="420" r="12" fill="#966374" />
+    <circle cx="300" cy="440" r="14" fill="#966374" />
+    <circle cx="285" cy="452" r="11" fill="#a87682" />
+    <circle cx="560" cy="210" r="12" fill="#a87682" />
+    <circle cx="550" cy="222" r="9" fill="#966374" />
+  </g>
+  <ellipse cx="505" cy="225" rx="14" ry="6" transform="rotate(25 505 225)" fill="#6d7a5e" filter="url(#blur-branch)" />
+  <ellipse cx="420" cy="342" rx="13" ry="6" transform="rotate(40 420 342)" fill="#6d7a5e" filter="url(#blur-branch)" />
+</svg>
+```
+
+- [ ] **Step 2: Run the parity test — expect PASS**
+
+Run:
+
+```bash
+dotnet test Sudoku.Tests --filter "FullyQualifiedName~SakuraBranchParityTests"
+```
+
+Expected: **PASS**. If it fails, compare the two SVG files attribute-by-attribute — every non-color attribute must be character-for-character identical.
+
+- [ ] **Step 3: Commit both SVGs and the now-green test together**
+
+```bash
+git add Sudoku.App/Resources/Images/sakura_branch_light.svg Sudoku.App/Resources/Images/sakura_branch_dark.svg
+git commit -m "feat: add sakura branch watercolor SVGs (light + dark themes)"
+```
+
+---
+
+## Task 5: Shift the board's row/column/box highlight color
+
+**Files:**
+- Modify: `Sudoku.App/Controls/SudokuBoardDrawable.cs:16` and `:28`
+
+- [ ] **Step 1: Update the two color constants**
+
+Open `Sudoku.App/Controls/SudokuBoardDrawable.cs`. Find the dark-theme field on line 16:
+
+```csharp
+private static readonly Color s_darkRelatedCell = Color.FromArgb("#2a2520");
+```
+
+Change to:
+
+```csharp
+private static readonly Color s_darkRelatedCell = Color.FromArgb("#2e2224");
+```
+
+Find the light-theme field on line 28:
+
+```csharp
+private static readonly Color s_lightRelatedCell = Color.FromArgb("#ebe4db");
+```
+
+Change to:
+
+```csharp
+private static readonly Color s_lightRelatedCell = Color.FromArgb("#f0ddda");
+```
+
+No other edits — selected-cell, same-number, and error colors stay as-is.
+
+- [ ] **Step 2: Build the solution**
+
+Run:
+
+```bash
+dotnet build Sudoku.Core Sudoku.Tests
+```
+
+Expected: build succeeds. (The MAUI app project itself is not built here — it's built in the visual-verification task at the end.)
+
+- [ ] **Step 3: Run the full test suite to confirm nothing regresses**
+
+Run:
+
+```bash
+dotnet test
+```
+
+Expected: all existing tests pass plus the new parity test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sudoku.App/Controls/SudokuBoardDrawable.cs
+git commit -m "feat: shift board related-cell highlight to blush pink"
+```
+
+---
+
+## Task 6: Add sakura overlay to MenuPage
+
+**Files:**
+- Modify: `Sudoku.App/Views/MenuPage.xaml`
+
+- [ ] **Step 1: Insert the Image as the first child of the outer Grid**
+
+Open `Sudoku.App/Views/MenuPage.xaml`. Find the outer `<Grid>` element (currently opens with `<Grid RowDefinitions="*,Auto" Padding="24">`).
+
+The existing structure is:
+
+```xml
+<Grid RowDefinitions="*,Auto" Padding="24">
+    <VerticalStackLayout VerticalOptions="Center" Spacing="8">
+        ...
+    </VerticalStackLayout>
+
+    <Button Text="&#9881; Settings" ... Grid.Row="1" ... />
+</Grid>
+```
+
+Insert a new `<Image>` as the **first child** of the Grid (before `<VerticalStackLayout>`). Because MAUI Grid renders children in document order with later children on top, placing the Image first means it sits behind everything else automatically — no `ZIndex` needed:
+
+```xml
+<Grid RowDefinitions="*,Auto" Padding="24">
+    <Image Source="{AppThemeBinding Light=sakura_branch_light.png, Dark=sakura_branch_dark.png}"
+           Grid.RowSpan="2"
+           InputTransparent="True"
+           Aspect="AspectFit"
+           HorizontalOptions="End"
+           VerticalOptions="Start"
+           WidthRequest="320"
+           HeightRequest="480" />
+
+    <VerticalStackLayout VerticalOptions="Center" Spacing="8">
+        ...
+    </VerticalStackLayout>
+
+    <Button Text="&#9881; Settings" ... Grid.Row="1" ... />
+</Grid>
+```
+
+The rest of the file is unchanged. `Padding="24"` on the Grid still applies to all children, so the Image has the same 24-pt inset as everything else.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Sudoku.App/Views/MenuPage.xaml
+git commit -m "feat: add sakura branch overlay to MenuPage"
+```
+
+---
+
+## Task 7: Add sakura overlay to SettingsPage
+
+**Files:**
+- Modify: `Sudoku.App/Views/SettingsPage.xaml`
+
+- [ ] **Step 1: Insert the Image as the first child of the outer Grid**
+
+Open `Sudoku.App/Views/SettingsPage.xaml`. Find the outer `<Grid RowDefinitions="Auto,*" Padding="24,16">` (around line 10).
+
+Existing structure:
+
+```xml
+<Grid RowDefinitions="Auto,*" Padding="24,16">
+    <HorizontalStackLayout Spacing="12">
+        ...
+    </HorizontalStackLayout>
+
+    <ScrollView Grid.Row="1" Margin="0,16,0,0">
+        ...
+    </ScrollView>
+</Grid>
+```
+
+Insert the Image as the first child:
+
+```xml
+<Grid RowDefinitions="Auto,*" Padding="24,16">
+    <Image Source="{AppThemeBinding Light=sakura_branch_light.png, Dark=sakura_branch_dark.png}"
+           Grid.RowSpan="2"
+           InputTransparent="True"
+           Aspect="AspectFit"
+           HorizontalOptions="End"
+           VerticalOptions="Start"
+           WidthRequest="320"
+           HeightRequest="480" />
+
+    <HorizontalStackLayout Spacing="12">
+        ...
+    </HorizontalStackLayout>
+
+    <ScrollView Grid.Row="1" Margin="0,16,0,0">
+        ...
+    </ScrollView>
+</Grid>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Sudoku.App/Views/SettingsPage.xaml
+git commit -m "feat: add sakura branch overlay to SettingsPage"
+```
+
+---
+
+## Task 8: Add sakura overlay to GamePage (masked by the board)
+
+**Files:**
+- Modify: `Sudoku.App/Views/GamePage.xaml`
+
+- [ ] **Step 1: Insert the Image as the first child of the outer Grid**
+
+Open `Sudoku.App/Views/GamePage.xaml`. Find the outer `<Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto" Padding="8">` (around line 10).
+
+Insert the Image as the **first child** of the Grid — before the Row 0 nav bar Grid:
+
+```xml
+<Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto" Padding="8">
+
+    <!-- Sakura branch overlay — masked by the opaque board in Row 2 -->
+    <Image Source="{AppThemeBinding Light=sakura_branch_light.png, Dark=sakura_branch_dark.png}"
+           Grid.RowSpan="6"
+           InputTransparent="True"
+           Aspect="AspectFit"
+           HorizontalOptions="End"
+           VerticalOptions="Start"
+           WidthRequest="320"
+           HeightRequest="480" />
+
+    <!-- Row 0: Navigation bar -->
+    <Grid ColumnDefinitions="Auto,*,Auto" Padding="8,4">
+        ...
+```
+
+The board's `GraphicsView` (Row 2) fills its cells with opaque colors in `SudokuBoardDrawable.DrawCellBackgrounds`, which naturally hides the branch anywhere the 9×9 grid overlaps. No explicit clipping logic needed.
+
+Also keep the existing `WinOverlay` Grid (with `Grid.RowSpan="6"`) that comes **after** everything else — because it is a later child, it will continue to render on top of both the content and the new sakura Image, so the win celebration still works correctly.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Sudoku.App/Views/GamePage.xaml
+git commit -m "feat: add sakura branch overlay to GamePage (masked by board)"
+```
+
+---
+
+## Task 9: Add the sakura branch behind the splash Ensō
+
+**Files:**
+- Modify: `Sudoku.App/Resources/Splash/splash.svg`
+
+- [ ] **Step 1: Rewrite the splash SVG with branch paths inserted before the Ensō paths**
+
+Current content of `Sudoku.App/Resources/Splash/splash.svg`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+    <!-- Ensō — zen brush-stroke circle, larger for splash -->
+    <!-- Center: (228, 228), radius: 120, gap at top-right -->
+
+    <!-- Main body — bold confident stroke -->
+    <path d="M 320 151 A 120 120 0 1 1 187 115"
+          fill="none" stroke="white" stroke-width="28" stroke-linecap="round"/>
+
+    <!-- Tapered tail — brush lifting gently -->
+    <path d="M 187 115 A 120 120 0 0 1 249 110"
+          fill="none" stroke="white" stroke-width="8" stroke-linecap="round"/>
+</svg>
+```
+
+Replace the entire file with:
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter id="splashBlur" x="-20%" y="-20%" width="140%" height="140%">
+            <feGaussianBlur stdDeviation="3" />
+        </filter>
+    </defs>
+
+    <!-- Sakura branch — light palette, painted BEFORE the Ensō so it sits behind -->
+    <path d="M 465 30 Q 410 70 380 120 Q 350 180 310 220"
+          fill="none" stroke="#a08778" stroke-width="3" opacity="0.5" filter="url(#splashBlur)" />
+    <g opacity="0.6" filter="url(#splashBlur)">
+        <circle cx="455" cy="35" r="14" fill="#f2cdd1" />
+        <circle cx="465" cy="50" r="12" fill="#edb9c2" />
+        <circle cx="445" cy="60" r="10" fill="#f2cdd1" />
+        <circle cx="410" cy="90" r="12" fill="#edb9c2" />
+        <circle cx="420" cy="105" r="10" fill="#f2cdd1" />
+        <circle cx="380" cy="135" r="11" fill="#f2cdd1" />
+        <circle cx="395" cy="150" r="9" fill="#edb9c2" />
+        <circle cx="350" cy="180" r="11" fill="#f2cdd1" />
+        <circle cx="335" cy="195" r="9" fill="#edb9c2" />
+        <circle cx="310" cy="215" r="10" fill="#f2cdd1" />
+    </g>
+    <ellipse cx="395" cy="125" rx="9" ry="4" transform="rotate(30 395 125)" fill="#a8b89a" opacity="0.55" filter="url(#splashBlur)" />
+
+    <!-- Ensō — zen brush-stroke circle, larger for splash -->
+    <!-- Center: (228, 228), radius: 120, gap at top-right -->
+    <!-- Main body — bold confident stroke -->
+    <path d="M 320 151 A 120 120 0 1 1 187 115"
+          fill="none" stroke="white" stroke-width="28" stroke-linecap="round"/>
+
+    <!-- Tapered tail — brush lifting gently -->
+    <path d="M 187 115 A 120 120 0 0 1 249 110"
+          fill="none" stroke="white" stroke-width="8" stroke-linecap="round"/>
+</svg>
+```
+
+Note: the splash uses the light palette only. Reasoning: MAUI splash is shown before the app's theme preference is reliably applied, and the existing Ensō is white regardless — a dark-specific splash is out of scope (see spec: "Out of scope").
+
+- [ ] **Step 2: Delete the resizetizer cache so the edited splash regenerates**
+
+Per the CLAUDE.md gotcha on resizetizer caching, run:
+
+```bash
+find Sudoku.App/obj -type d -name resizetizer -exec rm -rf {} + 2>/dev/null || true
+```
+
+(On Windows bash this removes the cached platform splash images. If the directory doesn't exist yet, the command exits cleanly.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sudoku.App/Resources/Splash/splash.svg
+git commit -m "feat: paint sakura branch behind Ensō on splash screen"
+```
+
+---
+
+## Task 10: Build + visual verification
+
+**Files:** no code changes — this is a human-judgement step.
+
+- [ ] **Step 1: Clean build the MAUI app for Windows**
+
+Run:
+
+```bash
+dotnet build Sudoku.App -f net10.0-windows10.0.19041.0
+```
+
+Expected: build succeeds. If the resizetizer errors on the new SVGs (missing filter support, filename casing, etc.), read the error carefully and fix in place.
+
+- [ ] **Step 2: Launch the Windows app**
+
+Run:
+
+```bash
+dotnet build Sudoku.App -f net10.0-windows10.0.19041.0 -t:Run
+```
+
+- [ ] **Step 3: Verify the four visual acceptance criteria**
+
+Tick each when observed on Windows:
+
+- [ ] Splash: cherry-blossom branch visible in the top-right corner behind the white Ensō; Ensō remains crisp on top.
+- [ ] MenuPage: branch visible in top-right, subtle; the existing title, difficulty buttons, and settings gear all render unchanged and tappable.
+- [ ] SettingsPage: branch visible in top-right; settings rows remain readable and interactive.
+- [ ] GamePage: branch visible above the nav bar / info bar in the top-right, **does not** appear through the 9×9 board (board cells are fully opaque); below the number pad is clean (no branch by design).
+- [ ] Select any cell in the board: row/column/box related cells tint a very subtle pink (`#f0ddda` in light, `#2e2224` in dark) — noticeably pink compared to the previous warm cream but not loud.
+- [ ] Toggle dark theme (Settings → Dark Theme): branch switches to dusty rose and the board's related-cell tint shifts appropriately.
+
+- [ ] **Step 4: If visuals need tuning, iterate on SVG coordinates / Image sizing**
+
+Expected iterations:
+
+- Branch sits in wrong part of page → adjust `WidthRequest` / `HeightRequest` on the `<Image>` in each View, or adjust the branch's coordinates inside the SVG (and mirror the change into the dark file — the parity test will catch a miss).
+- Branch looks too strong or too faint → adjust the root `opacity` attribute on each SVG (may differ between light and dark — this is explicitly allowed by the parity test).
+- Branch clips at filter edges → expand the filter region (`x="-20%" y="-20%" width="140%" height="140%"`) on `feGaussianBlur`.
+
+After any SVG edit, re-run the parity test:
+
+```bash
+dotnet test Sudoku.Tests --filter "FullyQualifiedName~SakuraBranchParityTests"
+```
+
+- [ ] **Step 5: Smoke-test Android if available**
+
+If an Android emulator is set up, run:
+
+```bash
+dotnet build Sudoku.App -f net10.0-android -t:Run
+```
+
+Walk through the same acceptance criteria. If Android rendering differs meaningfully (e.g. blur quality), note it but do not block merge — the feature still ships with light-theme-only splash by spec.
+
+- [ ] **Step 6: Commit any tuning edits made in Step 4**
+
+```bash
+git add Sudoku.App/Resources/Images/ Sudoku.App/Views/ Sudoku.App/Resources/Splash/splash.svg
+git commit -m "tune: adjust sakura branch sizing/opacity after visual review"
+```
+
+(Only commit if tuning was actually needed. If everything looked right first pass, skip this step.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage**: every section of the spec maps to a task — SVG assets (Tasks 3, 4), parity test (Tasks 1, 2), board highlight change (Task 5), page integration (Tasks 6, 7, 8), splash (Task 9), visual verification (Task 10). `Colors.xaml` explicitly not touched, as specified.
+- **Rendering of `AppThemeBinding` filename**: the plan references `sakura_branch_light.png` / `sakura_branch_dark.png` in XAML because MAUI's resizetizer emits PNG outputs from SVG sources. If the build complains, try `sakura_branch_light` (no extension) — this is a known per-version quirk of MAUI image referencing. Adjust and re-run; not worth a follow-up task.
+- **No placeholders**: every code block contains complete content; every command has expected output described.
+- **Type/signature consistency**: all references to `s_lightRelatedCell` / `s_darkRelatedCell` match the existing field names in `SudokuBoardDrawable.cs` verified against the file.
+- **Commit granularity**: one commit per task so a reviewer can bisect across the theme change cleanly.

--- a/docs/superpowers/specs/2026-04-21-cherry-blossom-theme-design.md
+++ b/docs/superpowers/specs/2026-04-21-cherry-blossom-theme-design.md
@@ -1,0 +1,217 @@
+# Cherry Blossom Theme — Design Spec
+
+**Date**: 2026-04-21
+**Status**: Draft — pending user review
+**Scope**: `Sudoku.App` (MAUI) + small test addition in `Sudoku.Tests`
+
+## Overview
+
+Add a subtle cherry-blossom visual accent to the existing zen earth-tone theme. The change is purely cosmetic and additive — no behavior, no save format, no API changes.
+
+Two concrete additions:
+
+1. A soft "watercolor" sakura branch appears in the top-right corner of every screen (MenuPage, GamePage, SettingsPage) and behind the Ensō on the splash screen.
+2. The board's row/column/box highlight — shown when a cell is selected — shifts from warm cream to a near-imperceptible pink.
+
+Every other visual element (sage-green accent, warm earth palette, typography, layout, number-pad, win overlay) remains unchanged.
+
+## Goals
+
+- Introduce a cherry-blossom visual signature across the app.
+- Preserve the app's zen/serene tone — the pink is a whisper, not a shout.
+- Keep the sage-green accent as the primary UI color (Continue button, win-card title, candidate-mode checkbox, player numbers, difficulty label). Pink is additive, not a rebrand.
+
+## Non-goals
+
+- No change to sage-green button/accent colors.
+- No change to selected-cell, same-number, or error-cell highlights on the board.
+- No change to Android adaptive icon or app icon — splash only.
+- No runtime theme customization (user-selectable accents, etc.). The light/dark pair is fixed.
+- No animations on the blossoms. Static imagery.
+
+## Design decisions (summary)
+
+| Decision | Choice |
+|---|---|
+| Pink accent strategy | Additive — only for board row/col/box highlight. Sage unchanged. |
+| Watercolor composition | Corner branch (sakura branch sweeping from top-right corner) |
+| Screen scope | MenuPage, SettingsPage, GamePage (margins only — board masks its area), Splash |
+| Position variation across screens | Same top-right anchor on every screen |
+| Dark-theme palette | Dusty rose at ~40% opacity (recessed but still clearly cherry blossom) |
+| Light-theme related-cell color | `#f0ddda` (halfway between whisper and blush) |
+| Dark-theme related-cell color | `#2e2224` (same "shift" applied to the existing warm dark cell tint) |
+| Splash integration | Ensō remains on top; branch painted behind it |
+| Rendering approach | Two static SVG files (light/dark variants) referenced via `AppThemeBinding` |
+| Source-of-truth enforcement | Parity test asserting geometry is identical across the two files |
+| GamePage bottom margin | No bottom branch — only the top-right anchor; bottom area stays clean |
+
+## Palette
+
+### Watercolor asset palette
+
+| Element | Light theme | Dark theme |
+|---|---|---|
+| Blossom — light petal | `#f2cdd1` | `#a87682` |
+| Blossom — deep petal | `#edb9c2` | `#966374` |
+| Branch bark | `#a08778` | `#6a4f40` |
+| Leaf | `#a8b89a` | `#6d7a5e` |
+| Root `<svg opacity>` | `0.55` | `0.4` |
+
+### Board related-cell highlight (light/dark theme)
+
+| Token | Before | After |
+|---|---|---|
+| `s_lightRelatedCell` | `#ebe4db` | `#f0ddda` |
+| `s_darkRelatedCell` | `#2a2520` | `#2e2224` |
+
+## Asset design
+
+Two SVG files live in `Sudoku.App/Resources/Images/`:
+
+- `sakura_branch_light.svg`
+- `sakura_branch_dark.svg`
+
+Both files share the same `viewBox` (portrait-ish canvas; exact dimensions tuned during implementation — a 600×1000 starting point is reasonable) and the same shape vocabulary:
+
+- 2 bezier paths: a main branch curving in from the top-right, plus one small offshoot.
+- ~10 blossom clusters. Each cluster is 2–3 overlapping `<circle>` elements using the two blossom colors from the palette.
+- 2 `<ellipse>` leaves in the sage-leaf color.
+- A single `<defs>` block defining two filters: one `feGaussianBlur` with `stdDeviation="2"` (applied to branch), one with `stdDeviation="4"` (applied to blossoms and leaves). Filters are referenced via `filter="url(#…)"` on the shapes.
+- Root `<svg opacity="…">` attribute controls the overall theme intensity.
+
+The branch composition occupies roughly the top-right 40% of the canvas, trailing down-left. Everything outside that area is transparent.
+
+Only color and opacity literals differ between `sakura_branch_light.svg` and `sakura_branch_dark.svg`. All geometry (`d`, `cx`, `cy`, `r`, `rx`, `ry`), element ordering, and filter structure are identical.
+
+## Page integration
+
+### MenuPage, SettingsPage
+
+Add a single `<Image>` as the first child of the root `Grid` in `Views/MenuPage.xaml` and `Views/SettingsPage.xaml`:
+
+```xml
+<Image Source="{AppThemeBinding Light=sakura_branch_light.png, Dark=sakura_branch_dark.png}"
+       Grid.RowSpan="2"
+       ZIndex="-1"
+       InputTransparent="True"
+       Aspect="AspectFit"
+       HorizontalOptions="End"
+       VerticalOptions="Start" />
+```
+
+(Both MenuPage and SettingsPage use `RowDefinitions="*,Auto"` / `"Auto,*"` respectively — `RowSpan="2"` covers the full layout on both.)
+
+Notes:
+
+- MAUI's resizetizer converts `.svg` in `Resources/Images/` to platform-native PNGs at build time. XAML references use the `.png` filename.
+- `ZIndex="-1"` keeps the image behind content.
+- `InputTransparent="True"` ensures taps pass through to underlying controls.
+- Sizing may need small platform-specific tuning (Windows vs Android). The anchor is top-right; exact `WidthRequest` / `HeightRequest` values are an implementation detail to settle during build-and-look iteration.
+
+### GamePage
+
+Same pattern in `Views/GamePage.xaml`, with `Grid.RowSpan="6"` covering the full outer `Grid`.
+
+The board's `GraphicsView` (at `Grid.Row="2"`) paints opaque cell backgrounds in `SudokuBoardDrawable.DrawCellBackgrounds` — the board naturally masks the branch in the board area. No explicit clipping is required.
+
+The branch is therefore visible:
+
+- Above the board (nav bar and info bar area).
+
+And hidden:
+
+- Behind the board (the opaque 9×9 grid covers any overlap).
+
+There is deliberately no branch below the board — the top-right anchor and single asset keeps bottom margins clean. (The bottom already carries the mode toggle, undo button, number pad, and auto-candidate row — visually full.)
+
+### Splash
+
+Edit `Sudoku.App/Resources/Splash/splash.svg` in place. Inline the branch paths from `sakura_branch_light.svg` (splash uses the light palette because MAUI splash renders before user theme preference is applied reliably).
+
+Draw order inside `splash.svg`:
+
+1. Branch paths and blossoms first (bottom layer).
+2. Existing Ensō paths last (top layer — Ensō sits visually in front).
+
+After editing `splash.svg`, the resizetizer output must be cleared (see Gotchas).
+
+## Board highlight change
+
+File: `Sudoku.App/Controls/SudokuBoardDrawable.cs`.
+
+Two `static readonly Color` fields change:
+
+- `s_lightRelatedCell`: `#ebe4db` → `#f0ddda`
+- `s_darkRelatedCell`: `#2a2520` → `#2e2224`
+
+No other fields change. The existing `DrawCellBackgrounds` and `GetCellColor` logic applies the new colors automatically. Selected-cell (`s_*SelectedCell`), same-number (`s_*SameNumber`), and error (`s_*ErrorCell`) colors are untouched — only the row/column/box "related" tint shifts.
+
+`Colors.xaml` needs no additions — the project's existing convention is that board colors live in `SudokuBoardDrawable.cs` as code constants, while resource-dictionary colors cover page/number-pad/difficulty surfaces.
+
+## Testing
+
+### SVG parity test
+
+New test file: `Sudoku.Tests/SakuraBranchParityTests.cs`.
+
+Intent: the two SVG files must share identical geometry. Only color and opacity attributes may differ. A test catches geometry drift when one file is edited and the other forgotten.
+
+Approach:
+
+1. Add `<None Include="..\Sudoku.App\Resources\Images\sakura_branch_*.svg" CopyToOutputDirectory="PreserveNewest" />` (or equivalent) to `Sudoku.Tests.csproj` so both files are available next to the test assembly at runtime.
+2. Load both files and parse them with `System.Xml.Linq.XDocument`.
+3. Walk the element trees in document order, pairing elements by index.
+4. For each paired element:
+   - Assert the tag name matches.
+   - Assert the **geometry attributes** match: `d`, `cx`, `cy`, `r`, `rx`, `ry`, `x`, `y`, `width`, `height`, `stroke-width`, `filter`, `id`.
+   - **Ignore** color/opacity attributes: `fill`, `stroke`, `opacity`, `stop-color`, `stop-opacity`, plus `stdDeviation` on `feGaussianBlur`.
+5. Assert both files have the same total element count.
+
+Any unexpected divergence — a different number of circles, a path with a different `d`, a missing filter reference — fails the test.
+
+### Board color smoke test (optional)
+
+Low-value but cheap: verify the two new hex values are present on `SudokuBoardDrawable`'s related-cell fields. This pins the spec values against accidental edits. Can be skipped if it feels excessive.
+
+### No visual regression tests
+
+Watercolor aesthetics are a human judgement. The developer building this feature must eyeball both themes on Windows and Android after build.
+
+## Gotchas
+
+- **Resizetizer caching** (from `CLAUDE.md`): after first adding the SVGs or editing `splash.svg`, delete `obj/**/resizetizer/` and rebuild. Otherwise changes may not appear.
+- **`feGaussianBlur` render region**: SkiaSharp's SVG renderer respects the filter element's `x/y/width/height` region. If blossom edges appear clipped, expand the filter region (e.g. `x="-20%" y="-20%" width="140%" height="140%"`).
+- **`dominant-baseline` unsupported** (from `CLAUDE.md`): not used here, but noted for future reference.
+- **Image anchoring across platforms**: `HorizontalOptions="End" VerticalOptions="Start"` with `AspectFit` may render slightly differently on Windows vs Android. Expect minor tuning of size properties on first build.
+- **Splash reads light palette**: on systems where dark-mode preference is available at splash time, the light-palette branch will still render (slight tonal mismatch for a split second). This is acceptable — splash is brief and the Ensō is white on warm background regardless of theme. If a dark splash is later desired, it's an MSBuild-config job and belongs in a separate change.
+
+## Rollout
+
+- Purely additive visual change.
+- No save-file, no enum, no API change. Existing save games load without migration.
+- Feature appears on next build / install.
+- No feature flag needed.
+
+## Out of scope / future work
+
+- Animated petals drifting across the screen (zen-breaking, not worth it).
+- Seasonal theme rotation (e.g. autumn leaves).
+- User-selectable accent colors.
+- A dark-specific splash screen (requires platform-specific splash configuration).
+
+## Files touched
+
+Created:
+
+- `Sudoku.App/Resources/Images/sakura_branch_light.svg`
+- `Sudoku.App/Resources/Images/sakura_branch_dark.svg`
+- `Sudoku.Tests/SakuraBranchParityTests.cs`
+
+Modified:
+
+- `Sudoku.App/Views/MenuPage.xaml` — adds one `<Image>`
+- `Sudoku.App/Views/SettingsPage.xaml` — adds one `<Image>`
+- `Sudoku.App/Views/GamePage.xaml` — adds one `<Image>`
+- `Sudoku.App/Controls/SudokuBoardDrawable.cs` — two color constant edits
+- `Sudoku.App/Resources/Splash/splash.svg` — branch paths added behind Ensō
+- `Sudoku.Tests/Sudoku.Tests.csproj` — copies the two SVGs into test output


### PR DESCRIPTION
## Summary
- Subtle sakura watercolor branch in the top-right of MenuPage, SettingsPage, and GamePage (masked by the opaque board in play), plus behind the Ensō on the splash screen.
- Board row/column/box highlight shifted to a near-imperceptible pink: `#f0ddda` (light) / `#2c2422` (dark). Selected-cell, same-number, and error colors unchanged.
- Two SVG variants (light/dark) with an `SakuraBranchParityTests` test that enforces identical geometry — edits to one SVG must match the other.

## Design & plan
- Spec: `docs/superpowers/specs/2026-04-21-cherry-blossom-theme-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-cherry-blossom-theme.md`

## Test plan
- [ ] `dotnet test` — 120/120 pass (SVG parity test included)
- [ ] Windows visual check: sakura branch visible top-right on Menu / Settings / Game (above the board only) / Splash (behind Ensō)
- [ ] Board highlight on light theme reads as subtle blush when a cell is selected
- [ ] Dark theme: both the branch (dusty rose) and the related-cell highlight adopt the muted palette
- [ ] Android smoke test (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cherry blossom overlay imagery with light/dark theme support to MenuPage, SettingsPage, and GamePage.
  * Updated MenuPage subheading text.

* **Style**
  * Refined "Related Cells" highlight colors in both light and dark themes.

* **Tests**
  * Added parity test to validate theme asset consistency.

* **Chores**
  * Updated documentation and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->