### PR TITLE
fix(android): lock app to portrait orientation

### DIFF
--- a/Sudoku.App/Platforms/Android/MainActivity.cs
+++ b/Sudoku.App/Platforms/Android/MainActivity.cs
@@ -4,7 +4,7 @@ using Android.OS;
 
 namespace Sudoku.App;
 
-[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+[Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ScreenOrientation = ScreenOrientation.Portrait, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
 }


### PR DESCRIPTION
## Summary

None of the screens have landscape layouts, so rotating the device on Android produced broken/clipped UI. This locks `MainActivity` to portrait orientation at the OS level, so Android never renders a landscape layout pass.

## Change

Single-line change to `Sudoku.App/Platforms/Android/MainActivity.cs` — added `ScreenOrientation = ScreenOrientation.Portrait` to the `[Activity]` attribute. `ScreenOrientation` was already in scope via the existing `Android.Content.PM` import; no XAML changes.

`ConfigChanges.Orientation` was intentionally left in place — harmless while locked, and avoids a surprise activity recreation if the lock is ever relaxed.

## Notes

- Windows is a resizable desktop app (no portrait concept) and there is no iOS target yet, so this is Android-only.
- Full landscape layouts remain a possible future enhancement (the board renderer is already size-agnostic; only the GamePage chrome would need adaptive layouts).

## Testing

Manually built, deployed, and verified portrait lock on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed screen orientation behavior on Android devices to ensure the app displays in portrait mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->